### PR TITLE
Fix array.toString() warnings

### DIFF
--- a/ping-monitor@samuel.bachmann.gmail.com/extension.js
+++ b/ping-monitor@samuel.bachmann.gmail.com/extension.js
@@ -806,7 +806,12 @@ const Ping = new Lang.Class({
         this._pingDataStdout.fill_async(-1, GLib.PRIORITY_DEFAULT, null, Lang.bind(this, function(stream, result) {
             if (stream.fill_finish(result) == 0) {
                 try {
-                    this._pingOutput = stream.peek_buffer().toString();
+                    if (stream.peek_buffer() instanceof Uint8Array) {
+                      this._pingOutput = imports.byteArray.toString(stream.peek_buffer())
+                    }
+                    else {
+                      this._pingOutput = stream.peek_buffer().toString();
+                    }
                     if (this._pingOutput) {
                         print_debug('Ping info: ' + this._pingOutput);
 
@@ -864,7 +869,12 @@ const Ping = new Lang.Class({
         this._pingDataStderr.fill_async(-1, GLib.PRIORITY_DEFAULT, null, Lang.bind(this, function(stream, result) {
             if (stream.fill_finish(result) == 0) {
                 try {
-                    this._pingOutputErr = stream.peek_buffer().toString();
+                    if (stream.peek_buffer() instanceof Uint8Array) {
+                      this._pingOutputErr = imports.byteArray.toString(stream.peek_buffer())
+                    }
+                    else {
+                      this._pingOutputErr = stream.peek_buffer().toString();
+                    }
                     if (this._pingOutputErr) {
                         this.ping_message = this._pingOutputErr;
                         print_debug('Ping error: ' + this.ping_message);


### PR DESCRIPTION
For the future, remember:
>Some code called array.toString() on a Uint8Array instance. Previously this would have interpreted the bytes of the array as a string, but that is nonstandard. In the future this will return the bytes as comma-separated digits. For the time being, the old behavior has been preserved, but please fix your code anyway to explicitly call ByteArray.toString(array).
